### PR TITLE
手动指定签发服务器为letsencrypt

### DIFF
--- a/trojan-go_install.sh
+++ b/trojan-go_install.sh
@@ -248,6 +248,7 @@ tls_generate() {
     fi
     
     "$HOME"/.acme.sh/acme.sh --set-default-ca --server letsencrypt;
+    echo -e "${Info} 设置默认签发服务器为letsencrypt"
 
     if "$HOME"/.acme.sh/acme.sh --issue -d "${domain}" --standalone -k ec-256 --force; then
         echo -e "${Info} TLS 证书生成成功 "

--- a/trojan-go_install.sh
+++ b/trojan-go_install.sh
@@ -246,6 +246,8 @@ tls_generate() {
         rm -rf "$HOME/.acme.sh/${domain}_ecc"
         exit 1
     fi
+    
+    "$HOME"/.acme.sh/acme.sh --set-default-ca --server letsencrypt;
 
     if "$HOME"/.acme.sh/acme.sh --issue -d "${domain}" --standalone -k ec-256 --force; then
         echo -e "${Info} TLS 证书生成成功 "


### PR DESCRIPTION
由于acme默认CA变为ZeroSSL，原脚本无法使用，需要手动指定使用letsencrypt